### PR TITLE
Reconstruct bpmn activity ids for resource utilization logs

### DIFF
--- a/src/main/java/de/hpi/bpt/scylla/plugin/statslogger_nojar/StatisticsLogger.java
+++ b/src/main/java/de/hpi/bpt/scylla/plugin/statslogger_nojar/StatisticsLogger.java
@@ -33,7 +33,7 @@ public class StatisticsLogger extends OutputLoggerPluggable {
     }
 
     public void writeToLog(SimulationModel model, String outputPathWithoutExtension) throws IOException {
-
+        
         TimeUnit timeUnit = DateTimeUtils.getReferenceTimeUnit();
         double totalEndTime = model.presentTime().getTimeAsDouble(timeUnit);
         Map<String, Map<Integer, List<ProcessNodeInfo>>> processNodeInfos = model.getProcessNodeInfos();
@@ -352,8 +352,12 @@ public class StatisticsLogger extends OutputLoggerPluggable {
         
             
             Map<String, Map<String, StatisticsTaskInstanceObject>> statsPerTaskOfProcess = statsPerTask.get(processId);
+            Map<Integer, String> originalIdentifiers = model.getDesmojObjectsMap().get(processId).getProcessModel().getIdentifiers();
             // add activities
             for (String processScopeNodeId : statsPerTaskOfProcess.keySet()) {
+
+
+                String originalId = originalIdentifiers.get(Integer.parseInt(processScopeNodeId));
             	
             	long taskDuration = 0;
             	for (StatisticsTaskInstanceObject instance : statsPerTaskOfProcess.get(processScopeNodeId).values()) {
@@ -372,7 +376,7 @@ public class StatisticsLogger extends OutputLoggerPluggable {
 	            Element activity = new Element("activity");
 	            processActivities.addContent(activity);
 	            
-	            activity.addContent(new Element("id").setText(processScopeNodeId));
+	            activity.addContent(new Element("id").setText(originalId));
 	            Element activityName = new Element("name");
 	            Element activityCost = new Element("cost");
 	            Element activityTime = new Element("time");


### PR DESCRIPTION
Hi, we found that there is some loss of information between the BPMN model input and the resulting resource utilization statistics, and also the XES Eventlog.

The "original" ids from the BPMN Model are lost during the simulation or not correctly mapped to the output.

For the StatisticsLogger, this PR provides a proptotype that at least worked for our case. Without, the "id"s in the resourceutilization file are just increasing integers.
But i wonder if there is a cleaner way, the `Integer.parseInt` part feels not safe.

Additionally, a similar confusing behaviour exists for the XES output, where the "concept:name" field is sometimes set to the BPMN id of the element, but sometimes also to the name if it is present. 

As the activity name is not guaranteed to be unique, it might be good to always set concept:name to the BPMN id? An alternative might be to use the "semantic:modelReference" attribute extension (https://www.tf-pm.org/resources/xes-standard/about-xes/standard-extensions/semantic) which seems to serve a similar purpose?